### PR TITLE
refactor(init): conform to naming conventions

### DIFF
--- a/early-init.el
+++ b/early-init.el
@@ -78,13 +78,13 @@
 ;;     (setq-default file-name-handler-alist nil)
 ;;     ;; ...but restore `file-name-handler-alist' later, because it is needed for
 ;;     ;; handling encrypted or compressed files, among other things.
-;;     (defun my/reset-file-handler-alist ()
+;;     (defun sthenno/reset-file-handler-alist ()
 ;;       (setq file-name-handler-alist
 ;;             ;; Merge instead of overwrite because there may have bene changes to
 ;;             ;; `file-name-handler-alist' since startup we want to preserve.
 ;;             (delete-dups (append file-name-handler-alist
 ;;                                  old-file-name-handler-alist))))
-;;     (add-hook 'emacs-startup-hook #'my/reset-file-handler-alist 101))
+;;     (add-hook 'emacs-startup-hook #'sthenno/reset-file-handler-alist 101))
 
 ;;   (setq-default inhibit-redisplay t
 ;;                 inhibit-message t)

--- a/lisp/init-comp.el
+++ b/lisp/init-comp.el
@@ -107,11 +107,11 @@
   (set-face-attribute 'vertico-group-title nil :slant 'normal)
 
   ;; Prefix candidates
-  (defvar my/vertico-using-prefix-symbol-p t)
+  (defvar sthenno/vertico-using-prefix-symbol-p t)
 
   (cl-defmethod vertico--format-candidate :around
     (cand prefix suffix index start &context
-          ((and my/vertico-using-prefix-symbol-p
+          ((and sthenno/vertico-using-prefix-symbol-p
                 (not (bound-and-true-p vertico-flat-mode)))
            (eql t)))
     (setq cand (cl-call-next-method cand prefix suffix index start))
@@ -205,7 +205,7 @@
     '((t :inherit font-lock-string-face))
     "Face for `consult' framed buffers.")
 
-  (defun my-beframe-buffer-names-sorted (&optional frame)
+  (defun sthenno/beframe-buffer-names-sorted (&optional frame)
     "Return the list of buffers from `beframe-buffer-names' sorted by visibility.
 With optional argument FRAME, return the list of buffers of FRAME."
     (beframe-buffer-names frame :sort #'beframe-buffer-sort-visibility))
@@ -216,7 +216,7 @@ With optional argument FRAME, return the list of buffers of FRAME."
        :category buffer
        :face     beframe-buffer
        :history  beframe-history
-       :items    ,#'my-beframe-buffer-names-sorted
+       :items    ,#'sthenno/beframe-buffer-names-sorted
        :action   ,#'switch-to-buffer
        :state    ,#'consult--buffer-state))
 
@@ -269,7 +269,7 @@ and each value is a list of functions to add to `completion-at-point-functions'.
                     (dolist (func functions)
                       (add-to-list 'completion-at-point-functions func)))))))
 
-  (defvar my/capfs-map-alist
+  (defvar sthenno/capfs-map-alist
     '((prog-mode       . (cape-dict
                           cape-file
                           cape-dabbrev))
@@ -286,7 +286,7 @@ and each value is a list of functions to add to `completion-at-point-functions'.
     "An alist of (mode . list-of-capfs) to append.
 Elements in list-of-capfs further down the list have deeper priority in completion.")
 
-  (completion-at-point-functions-setup my/capfs-map-alist))
+  (completion-at-point-functions-setup sthenno/capfs-map-alist))
 
 
 ;;

--- a/lisp/init-editing-utils.el
+++ b/lisp/init-editing-utils.el
@@ -16,27 +16,27 @@
 ;; Global functions for editing enhancement
 ;;
 
-(defun my/delete-current-line ()
+(defun sthenno/delete-current-line ()
   "Delete the current line."
   (interactive)
   (delete-region (line-beginning-position) (line-beginning-position 2))
-  (run-hooks 'my/delete-current-line-hook))
+  (run-hooks 'sthenno/delete-current-line-hook))
 
-(defun my/delete-to-beginning-of-line ()
+(defun sthenno/delete-to-beginning-of-line ()
   "Delete from the current position to the beginning of the line."
   (interactive)
   (delete-region (line-beginning-position) (point)))
 
-(global-set-key (kbd "s-<backspace>") #'my/delete-current-line)
-(global-set-key (kbd "C-<backspace>") #'my/delete-to-beginning-of-line)
+(global-set-key (kbd "s-<backspace>") #'sthenno/delete-current-line)
+(global-set-key (kbd "C-<backspace>") #'sthenno/delete-to-beginning-of-line)
 
-(defun my/open-newline-below ()
+(defun sthenno/open-newline-below ()
   "Open a new line below the current one and move the cursor to it."
   (interactive)
   (end-of-line)
   (newline-and-indent))
 
-(global-set-key (kbd "s-<return>") #'my/open-newline-below)
+(global-set-key (kbd "s-<return>") #'sthenno/open-newline-below)
 
 ;; Pretty-print
 ;;
@@ -44,8 +44,8 @@
 ;; language. For example, formatters like Black are preferred over `indent-region' and
 ;; `untabify' for formatting Python code since a formatter usually provides a full
 ;; combination of executions that covers the basic functions that Emacs provides. Thus,
-;; behaviors of `my/pretty-print-current-buffer' should be considered separately for
-;; each particular case especially when `my/enable-pretty-print-on-save' is demanded.
+;; behaviors of `sthenno/pretty-print-current-buffer' should be considered separately for
+;; each particular case especially when `sthenno/enable-pretty-print-on-save' is demanded.
 ;;
 ;; NOTE: I did not intentionally distinguish between Indent, Pretty-print, and Format,
 ;; although there are minor differences in their applicable scenarios. Any
@@ -82,7 +82,7 @@ If `major-mode' is `python-mode', abort."
     (untabify (point-min) (point-max)))
   (run-hooks 'untabify-current-buffer-hook))
 
-(defun my/pretty-print-current-buffer ()
+(defun sthenno/pretty-print-current-buffer ()
   "Pretty print current buffer."
   (interactive)
   (save-excursion
@@ -90,15 +90,15 @@ If `major-mode' is `python-mode', abort."
     (indent-current-comment-buffer)
     (untabify-current-buffer)
     (delete-trailing-whitespace))
-  (run-hooks 'my/pretty-print-current-buffer-hook))
+  (run-hooks 'sthenno/pretty-print-current-buffer-hook))
 
-(defun my/enable-pretty-print-on-save ()
+(defun sthenno/enable-pretty-print-on-save ()
   "Enable pretty print before save in `emacs-lisp-mode'."
-  (add-hook 'before-save-hook #'my/pretty-print-current-buffer nil t))
+  (add-hook 'before-save-hook #'sthenno/pretty-print-current-buffer nil t))
 
-(add-hook 'emacs-lisp-mode-hook #'my/enable-pretty-print-on-save)
+(add-hook 'emacs-lisp-mode-hook #'sthenno/enable-pretty-print-on-save)
 
-(global-set-key (kbd "s-p") #'my/pretty-print-current-buffer)
+(global-set-key (kbd "s-p") #'sthenno/pretty-print-current-buffer)
 
 
 ;; TODO: Vundo
@@ -112,7 +112,7 @@ If `major-mode' is `python-mode', abort."
 ;; Fold code lines
 (use-package hideshow
   :config
-  (defun my-hs-set-up-overlay (ov)
+  (defun sthenno/hs-set-up-overlay (ov)
     (define-fringe-bitmap 'hs-marker [0 24 24 126 126 24 24 0]) ; A plus sign
     (modus-themes-with-colors
       (when (eq 'code (overlay-get ov 'hs))
@@ -128,7 +128,7 @@ If `major-mode' is `python-mode', abort."
                              display-string)
           (overlay-put ov 'display display-string)))))
 
-  (setq hs-set-up-overlay #'my-hs-set-up-overlay)
+  (setq hs-set-up-overlay #'sthenno/hs-set-up-overlay)
 
   (add-hook 'prog-mode-hook #'(lambda ()
                                 (hs-minor-mode 1)))
@@ -156,7 +156,7 @@ If `major-mode' is `python-mode', abort."
 
 ;; HACK: Inhibit passing these delimiters
 ;;
-;; (defun my-inhibit-specific-delimiters ()
+;; (defun sthenno/inhibit-specific-delimiters ()
 ;;   "Remove the following from current `syntax-table'. This disables syntax highlighting
 ;; and auto-paring for such entries."
 ;;   (modify-syntax-entry ?< "." (syntax-table))
@@ -244,9 +244,9 @@ If `major-mode' is `python-mode', abort."
   (add-hook 'indent-current-buffer-hook #'pulsar-pulse-line-cyan)
   (add-hook 'after-save-hook #'pulsar-pulse-line-green)
 
-  (add-hook 'my/delete-current-line-hook #'pulsar-pulse-line-magenta)
-  (add-hook 'my/cycle-to-next-buffer-hook #'pulsar-pulse-line-cyan)
-  (add-hook 'my/cycle-to-previous-buffer-hook #'pulsar-pulse-line-cyan)
+  (add-hook 'sthenno/delete-current-line-hook #'pulsar-pulse-line-magenta)
+  (add-hook 'sthenno/cycle-to-next-buffer-hook #'pulsar-pulse-line-cyan)
+  (add-hook 'sthenno/cycle-to-previous-buffer-hook #'pulsar-pulse-line-cyan)
 
   (add-hook 'isearch-mode-end-hook #'pulsar-highlight-line)
 
@@ -286,7 +286,7 @@ If `major-mode' is `python-mode', abort."
 (use-package hl-todo
   :straight t
   :init
-  (defun my-hl-todo-faces-setup ()
+  (defun sthenno/hl-todo-faces-setup ()
     (modus-themes-with-colors
       (setq hl-todo-keyword-faces
             `(("TODO"  . ,prose-todo)
@@ -295,7 +295,7 @@ If `major-mode' is `python-mode', abort."
               ("NOTE"  . ,fg-changed)
               ("HACK"  . ,fg-changed)))))
 
-  (add-hook 'after-init-hook #'my-hl-todo-faces-setup)
+  (add-hook 'after-init-hook #'sthenno/hl-todo-faces-setup)
 
   (global-hl-todo-mode 1))
 

--- a/lisp/init-eglot.el
+++ b/lisp/init-eglot.el
@@ -103,7 +103,7 @@
 
   ;; Use Ollama as the default backend
   ;;
-  (defun my-gptel-ollama-backend--host (host)
+  (defun sthenno/gptel-ollama-backend--host (host)
     "Make a function to initialize an Ollama backend using the given HOST."
     `(lambda (model)
        (gptel-make-ollama model
@@ -111,13 +111,13 @@
          :stream t
          :models `(,model))))
 
-  (defun my-gptel-ollama-backend--localhost (model)
+  (defun sthenno/gptel-ollama-backend--localhost (model)
     "Initialize an Ollama backend using localhost and the given MODEL."
-    (funcall (my-gptel-ollama-backend--host "localhost:11434") model))
+    (funcall (sthenno/gptel-ollama-backend--host "localhost:11434") model))
 
   ;; Setup the model
   (let* ((model "phi3")
-         (backend (my-gptel-ollama-backend--localhost model)))
+         (backend (sthenno/gptel-ollama-backend--localhost model)))
     (setq gptel-model model
           gptel-backend backend))
 
@@ -130,18 +130,18 @@
   (add-hook 'gptel-post-response-functions #'gptel-end-of-response)
 
   :config
-  (setq my-gptel-input-count 0)
+  (setq sthenno/gptel-input-count 0)
 
-  (defun my-gptel-prefix ()
-    (setq my-gptel-input-count (1+ my-gptel-input-count))
-    (let* ((cnt my-gptel-input-count)
+  (defun sthenno/gptel-prefix ()
+    (setq sthenno/gptel-input-count (1+ sthenno/gptel-input-count))
+    (let* ((cnt sthenno/gptel-input-count)
            (prefix-in  (format "_In[%s]:=_ " cnt))
            (prefix-out (format "_Out[%s]=_ " (1- cnt))))
       (setq gptel-prompt-prefix-alist   `((org-mode . ,prefix-in))
             gptel-response-prefix-alist `((org-mode . ,prefix-out)))))
 
-  (add-hook 'gptel-mode-hook         #'my-gptel-prefix)
-  (add-hook 'gptel-pre-response-hook #'my-gptel-prefix)
+  (add-hook 'gptel-mode-hook         #'sthenno/gptel-prefix)
+  (add-hook 'gptel-pre-response-hook #'sthenno/gptel-prefix)
 
   ;; HACK
   ;;
@@ -171,27 +171,27 @@
 
   ;; Add loading message to `gptel-send'
   ;;
-  (defun my-gptel--loading-msg (loading-msg)
+  (defun sthenno/gptel--loading-msg (loading-msg)
     "Propertize LOADING-MSG using specified `text-properties'."
     (modus-themes-with-colors
       (let ((msg (propertize loading-msg
                              'face `(:foreground ,magenta-intense :inherit 'bold))))
         msg)))
 
-  (defun my-gptel-send-querying-loading ()
+  (defun sthenno/gptel-send-querying-loading ()
     "Now-loading behavior of `gptel-send' during querying."
-    (let ((msg (my-gptel--loading-msg
+    (let ((msg (sthenno/gptel--loading-msg
                 (format "✿ 少女祈祷中 􀍠 [%s]"
                         (gptel-backend-name gptel-backend)))))
       (start-loading-animation msg)))
 
-  (defun my-gptel-send-insert-loading ()
+  (defun sthenno/gptel-send-insert-loading ()
     "Now-loading behavior of `gptel-send' during inserting."
-    (let ((msg (my-gptel--loading-msg "􁄤 少女响应中 􀍠")))
+    (let ((msg (sthenno/gptel--loading-msg "􁄤 少女响应中 􀍠")))
       (stop-loading-animation)
       (message msg)))
 
-  (add-hook 'gptel-pre-response-hook #'my-gptel-send-insert-loading)
+  (add-hook 'gptel-pre-response-hook #'sthenno/gptel-send-insert-loading)
 
   ;; HACK
   (defun gptel-send (&optional arg)
@@ -211,7 +211,7 @@ waiting for the response."
     (interactive "P")
     (if (and arg (require 'gptel-transient nil t))
         (call-interactively #'gptel-menu)
-      (my-gptel-send-querying-loading)
+      (sthenno/gptel-send-querying-loading)
       (gptel--sanitize-model)
       (gptel-request nil :stream gptel-stream)
       (gptel--update-status " Waiting..." 'warning)))
@@ -220,7 +220,7 @@ waiting for the response."
   ;;
   (add-hook 'gptel-mode-hook #'turn-on-visual-line-mode)
 
-  (defun my-gptel-to-buffer ()
+  (defun sthenno/gptel-to-buffer ()
     "Open the gptel buffer."
     (interactive)
     (let ((buff "*Φ*"))
@@ -229,7 +229,7 @@ waiting for the response."
       ;; TODO: Add repeat keys to jump back
       (switch-to-buffer buff)))
 
-  (global-set-key (kbd "s-l") #'my-gptel-to-buffer)
+  (global-set-key (kbd "s-l") #'sthenno/gptel-to-buffer)
 
   :bind (:map gptel-mode-map
               ("S-<return>" . gptel-send)))

--- a/lisp/init-gui-frames.el
+++ b/lisp/init-gui-frames.el
@@ -172,8 +172,8 @@
 ;; - Add `magit' integration
 ;;
 
-(defun my-modeline-buffer-identification-setup ()
-  (defun my-modeline--buffer-identification ()
+(defun sthenno/modeline-buffer-identification-setup ()
+  (defun sthenno/modeline--buffer-identification ()
     "Return `buffer-name' as a string.
 If `buffer-file-name' is a `denote' file, return its corresponding title instead."
     (let ((file (buffer-file-name)))
@@ -181,26 +181,26 @@ If `buffer-file-name' is a `denote' file, return its corresponding title instead
           (format "[denote:%s]" (denote-retrieve-filename-title (buffer-file-name)))
         (buffer-name))))
 
-  (defvar-local my-modeline-buffer-identification
+  (defvar-local sthenno/modeline-buffer-identification
       '(:eval
         (when (mode-line-window-selected-p)
-          (propertize (my-modeline--buffer-identification) 'face 'mode-line-buffer-id)))
+          (propertize (sthenno/modeline--buffer-identification) 'face 'mode-line-buffer-id)))
     "Mode line construct to display the buffer identification.")
 
-  (defvar-local my-modeline-prefix-symbol
+  (defvar-local sthenno/modeline-prefix-symbol
       (modus-themes-with-colors
         (propertize "  Sthenno ◈" 'face
                     `(:foreground ,sthenno-gorse :inherit mode-line-buffer-id))))
 
-  (setq-default mode-line-format `(,my-modeline-prefix-symbol
+  (setq-default mode-line-format `(,sthenno/modeline-prefix-symbol
                                    "  "
-                                   ,my-modeline-buffer-identification
+                                   ,sthenno/modeline-buffer-identification
                                    "  "
                                    mode-line-modes
                                    mode-line-misc-info
                                    mode-line-end-spaces)))
 
-(add-hook 'after-init-hook #'my-modeline-buffer-identification-setup)
+(add-hook 'after-init-hook #'sthenno/modeline-buffer-identification-setup)
 
 ;; TODO
 ;; (use-package minions

--- a/lisp/init-org.el
+++ b/lisp/init-org.el
@@ -66,14 +66,14 @@
 ;; Preview functions
 ;;
 
-(defun my-org-preview-fragments ()
+(defun sthenno/org-preview-fragments ()
   (interactive)
   ;; (call-interactively 'org-latex-preview-clear-cache)
   ;; (org-latex-preview 'buffer)
   (org-redisplay-inline-images))
 
 (bind-keys :map org-mode-map
-           ("s-p" . my-org-preview-fragments))
+           ("s-p" . sthenno/org-preview-fragments))
 
 ;; (setq org-latex-packages-alist
 ;;       '(("T1" "fontenc" t)
@@ -106,13 +106,13 @@
 
 ;; (setq org-latex-preview-process-default 'dvisvgm)
 
-;; (defvar my/libgs-dylib-path "/opt/homebrew/opt/ghostscript/lib/libgs.10.03.dylib"
+;; (defvar sthenno/libgs-dylib-path "/opt/homebrew/opt/ghostscript/lib/libgs.10.03.dylib"
 ;;   "Path to Ghostscript shared library.")
 
 ;; (setq dvisvgm-image-converter-command
 ;;       (list (concat "dvisvgm --page=1- --optimize --clipjoin --relative --no-fonts "
 ;;                     "--exact-bbox --bbox=preview "
-;;                     "--libgs=" my/libgs-dylib-path " "
+;;                     "--libgs=" sthenno/libgs-dylib-path " "
 ;;                     "-v4 -o %B-%%9p.svg %f")))
 
 ;; (setq org-latex-preview-process-alist
@@ -147,14 +147,14 @@
   (setq org-modern-block-name '(("src" . ("􀃤" "􀃤"))))
 
   ;; From https://github.com/karthink/.emacs.d/blob/master/lisp/setup-org.el
-  (defun my-org-modern-spacing ()
+  (defun sthenno/org-modern-spacing ()
     "Adjust line-spacing for `org-modern' to correct svg display.
       This is useful if using font Iosevka."
     (setq-local line-spacing (if org-modern-mode
                                  0.1
                                0.0)))
 
-  (add-hook 'org-modern-mode-hook #'my-org-modern-spacing)
+  (add-hook 'org-modern-mode-hook #'sthenno/org-modern-spacing)
 
   (global-org-modern-mode 1))
 
@@ -245,11 +245,11 @@
 ;; Extensions for Denote [TODO] Add `consult-denote' support
 
 ;; Custom functions for Denote [TODO]
-(defun my/denote-insert-links-current-month ()
+(defun sthenno/denote-insert-links-current-month ()
   (interactive)
   (denote-add-links (format-time-string "%B")))
 
-(defun my/denote-open-previous-file ()
+(defun sthenno/denote-open-previous-file ()
   (interactive)
   (let* ((current-file (buffer-file-name))
          (directory (file-name-directory current-file))
@@ -260,7 +260,7 @@
     (when (and current-file-index (> current-file-index 0))
       (find-file (nth (1- current-file-index) sorted-files)))))
 
-(defun my/denote-open-next-file ()
+(defun sthenno/denote-open-next-file ()
   (interactive)
   (let* ((current-file (buffer-file-name))
          (directory (file-name-directory current-file))
@@ -272,8 +272,8 @@
       (find-file (nth (1+ current-file-index) sorted-files)))))
 
 (bind-keys :map org-mode-map
-           ("s-<up>"   . my/denote-open-previous-file)
-           ("s-<down>" . my/denote-open-next-file))
+           ("s-<up>"   . sthenno/denote-open-previous-file)
+           ("s-<down>" . sthenno/denote-open-next-file))
 
 
 ;; Load languages for Org Babel
@@ -311,7 +311,7 @@
 
 
 ;; Useful functions
-;; (defun my/org-mode-insert-get-button ()
+;; (defun sthenno/org-mode-insert-get-button ()
 ;;   "Inserts a button that copies a user-defined string to clipboard."
 ;;   (interactive)
 ;;   (let ((content (read-string "Content: ")))
@@ -323,7 +323,7 @@
 ;; Integrate with built-in Python API -> `init-eglot'
 ;;
 ;; TTS implementation using OpenAI's API
-;; (defun my/content-by-key-from-file (filename key)
+;; (defun sthenno/content-by-key-from-file (filename key)
 ;;   "Get content string of KEY from FILENAME."
 ;;   (with-temp-buffer
 ;;     (insert-file-contents filename)
@@ -332,23 +332,23 @@
 ;;  (match-string 1)
 ;;       (error "Key %s not found in file %s" key filename))))
 
-;; (defun my/environ-from-user-emacs-dir (key)
+;; (defun sthenno/environ-from-user-emacs-dir (key)
 ;;   "Get environ content by KEY from .env file in `user-emacs-directory'."
 ;;   (let ((filename (concat user-emacs-directory ".env")))
-;;     (my/content-by-key-from-file filename key)))
+;;     (sthenno/content-by-key-from-file filename key)))
 
-;; (setq my/openai-api-key
-;;       (my/environ-from-user-emacs-dir "OPENAI_API_KEY"))
+;; (setq sthenno/openai-api-key
+;;       (sthenno/environ-from-user-emacs-dir "OPENAI_API_KEY"))
 
 ;; (require 'json)
 
-;; (defun my/speech-from-str-to-file (input-string output-file)
+;; (defun sthenno/speech-from-str-to-file (input-string output-file)
 ;;   "Send a text-to-speech request to the OpenAI API and save the
 ;; result to OUTPUT-FILE."
 ;;   (let* ((url "https://api.openai.com/v1/audio/speech")
 ;;          (url-request-method "POST")
 ;;          (url-request-extra-headers
-;;           `(("Authorization" . ,(concat "Bearer " my/openai-api-key))
+;;           `(("Authorization" . ,(concat "Bearer " sthenno/openai-api-key))
 ;;             ("Content-Type" . "application/json")))
 ;;          (url-request-data
 ;;           (json-encode `(("model" . "tts-1")
@@ -362,13 +362,13 @@
 ;;         (write-region (point) (point-max) output-file))
 ;;       (kill-buffer buffer))))
 
-;; (defun my/generate-timestamp ()
+;; (defun sthenno/generate-timestamp ()
 ;;   "Generate a timestamp in the format YYYYMMDDTHHMMSS."
 ;;   (format-time-string "%Y%m%dT%H%M%S"))
 
-;; (setq my/speach-files-dir (concat org-directory "medi/"))
+;; (setq sthenno/speach-files-dir (concat org-directory "medi/"))
 
-;; (defun my/speech-from-str-to-file-insert ()
+;; (defun sthenno/speech-from-str-to-file-insert ()
 ;;   "Send the selected text to the OpenAI API and insert the result at
 ;; the point."
 ;;   (interactive)
@@ -376,20 +376,20 @@
 ;;       (let* ((start (region-beginning))
 ;;       (end (region-end))
 ;;       (input-string (buffer-substring-no-properties start end))
-;;       (filename (concat my/speach-files-dir
-;;                 "speach-" (my/generate-timestamp) ".mp3"))
+;;       (filename (concat sthenno/speach-files-dir
+;;                 "speach-" (sthenno/generate-timestamp) ".mp3"))
 ;;       (button-string
 ;;        (format "[[elisp:(emms-play-file \"%s\")][[􀊨]]]" filename)))
-;;  (my/speech-from-str-to-file input-string filename)
+;;  (sthenno/speech-from-str-to-file input-string filename)
 ;;  (goto-char end)
 ;;  (insert (concat " " button-string))
 ;;  (message (format "TTS finished to file %s" filename)))
 ;;     (message "No region selected")))
 
 ;; (bind-keys* :map org-mode-map
-;;      ("s-[ s" . my/speech-from-str-to-file-insert))
+;;      ("s-[ s" . sthenno/speech-from-str-to-file-insert))
 
-;; (defun my/play-speach-current-heading ()
+;; (defun sthenno/play-speach-current-heading ()
 ;;   "Play the speach audio if there is exactly one in current heading."
 ;;   (interactive)
 ;;   (save-excursion
@@ -421,6 +421,6 @@
 ;;   :config
 ;;   (setq org-drill-learn-fraction 0.5)
 ;;   (setq org-drill-maximum-items-per-session 20)
-;;   (add-hook 'org-drill-display-answer-hook #'my/play-speach-current-heading))
+;;   (add-hook 'org-drill-display-answer-hook #'sthenno/play-speach-current-heading))
 
 (provide 'init-org)

--- a/lisp/init-projects.el
+++ b/lisp/init-projects.el
@@ -34,7 +34,7 @@
   ;; [FIXME]
   ;;
 
-  (defun my/project-remove-project ()
+  (defun sthenno/project-remove-project ()
     "Remove project from `project--list' using completion."
     (interactive)
     (project--ensure-read-project-list)
@@ -43,7 +43,7 @@
       (setq project--list (delete (assoc dir projects) projects))))
 
   :bind (:map global-map
-              ("C-x p <backspace>" . my/project-remove-project)))
+              ("C-x p <backspace>" . sthenno/project-remove-project)))
 
 
 ;; Git client using Magit

--- a/lisp/init-system.el
+++ b/lisp/init-system.el
@@ -201,26 +201,26 @@ Activate again to undo this. If the window changes before then, the undo expires
 (global-set-key (kbd "<f12>") 'open-emacs-config-dir)
 
 ;; Ignore temporary buffers
-(defun my/filtered-cycle-buffer (cycle-func)
+(defun sthenno/filtered-cycle-buffer (cycle-func)
   (let ((original-buffer (current-buffer)))
     (funcall cycle-func)
     (while (and (string-match-p "\\*.*\\*" (buffer-name))
                 (not (eq original-buffer (current-buffer))))
       (funcall cycle-func))))
 
-(defun my/cycle-to-next-buffer ()
+(defun sthenno/cycle-to-next-buffer ()
   (interactive)
-  (my/filtered-cycle-buffer 'next-buffer)
-  (run-hooks 'my/cycle-to-next-buffer-hook))
+  (sthenno/filtered-cycle-buffer 'next-buffer)
+  (run-hooks 'sthenno/cycle-to-next-buffer-hook))
 
-(defun my/cycle-to-previous-buffer ()
+(defun sthenno/cycle-to-previous-buffer ()
   (interactive)
-  (my/filtered-cycle-buffer 'previous-buffer)
-  (run-hooks 'my/cycle-to-previous-buffer-hook))
+  (sthenno/filtered-cycle-buffer 'previous-buffer)
+  (run-hooks 'sthenno/cycle-to-previous-buffer-hook))
 
 (bind-keys :map global-map
-           ("<s-right>" . my/cycle-to-next-buffer)
-           ("<s-left>" . my/cycle-to-previous-buffer))
+           ("<s-right>" . sthenno/cycle-to-next-buffer)
+           ("<s-left>" . sthenno/cycle-to-previous-buffer))
 
 
 ;; Mouse and scroll settings

--- a/lisp/init-temp.el
+++ b/lisp/init-temp.el
@@ -36,7 +36,7 @@
   (yas-global-mode 1))
 
 ;; YASnippet functions
-(defun my/yas-insert-latex-matrix ()
+(defun sthenno/yas-insert-latex-matrix ()
   "Insert a LaTeX matrix at the current cursor position."
   (interactive)
   (let* ((rows (read-number "# Rows: "))
@@ -54,6 +54,6 @@
     (yas-expand-snippet snippet)))
 
 (bind-keys :map org-mode-map
-           ("s-i m" . my/yas-insert-latex-matrix))
+           ("s-i m" . sthenno/yas-insert-latex-matrix))
 
 (provide 'init-temp)


### PR DESCRIPTION
Use `sthenno/` as the prefix of custom features.
Prefix `sthenno-` is planned for future sthenno related modules.