### PR TITLE
Guard local org load path resolution

### DIFF
--- a/init.el
+++ b/init.el
@@ -125,11 +125,12 @@
   :init (when (memq window-system '(mac ns x))
           (exec-path-from-shell-initialize)))
 
-;; Load the patched `org'
-(progn
-  (add-to-list 'load-path "/Users/sthenno/.emacs.d/site-lisp/org/lisp/")
-  (setq features (delq 'org features))
-  (require 'org))
+;; Load the patched `org' if available (skip on non-macOS or fresh setups).
+(let ((org-site-lisp (locate-user-emacs-file "site-lisp/org/lisp")))
+  (when (file-directory-p org-site-lisp)
+    (add-to-list 'load-path org-site-lisp)
+    (setq features (delq 'org features))
+    (require 'org)))
 
 ;; Declare interactive functions used at startup to inform the byte-compiler
 (let ((startup-buffer 'denote-journal-new-or-existing-entry))


### PR DESCRIPTION
### Motivation
- Avoid a hard-coded macOS-specific path (`/Users/.../.emacs.d/...`) for loading a patched `org`.
- Use an Emacs-relative path so the configuration works across machines and portable setups.
- Skip loading the patched `org` when the local site-lisp directory does not exist (fresh installs or non-macOS machines) to prevent load errors.

### Description
- Replace the hard-coded `add-to-list` path with a user-emacs-directory relative value using `(locate-user-emacs-file "site-lisp/org/lisp")`.
- Wrap the `add-to-list` + `require` calls in a `when (file-directory-p org-site-lisp)` guard to only load if the directory exists.
- Use a `let` binding for `org-site-lisp` and add a brief comment explaining the fallback/guard behavior.

### Testing
- No automated tests were run.
- Change was reviewed by inspecting the updated `init.el` and successfully committed to the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944bb9f14e88328855d6f5d8ad5b6c6)